### PR TITLE
refactor: remove redundant code and preserve YAML order

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     yamlflattener = {
       source  = "Perun-Engineering/yamlflattener"
-      version = "~> 0.1"
+      version = "~> 0.2"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # Terraform YAML Flattener Provider
 
-A Terraform provider that flattens nested YAML structures into flat key-value maps with dot notation for objects and bracket notation for arrays.
+A Terraform provider that flattens nested YAML structures into flat key-value maps with dot notation for objects and bracket notation for arrays. **Preserves the original YAML key order** for consistent and predictable results.
 
 ## Why This Provider?
 
 When using the [Helm provider](https://registry.terraform.io/providers/hashicorp/helm/latest/docs), you can define sensitive variables using `set_sensitive` blocks. However, Terraform lacks a built-in function to flatten nested YAML structures, making it difficult to dynamically create `set_sensitive` blocks for complex configurations with nested objects and arrays.
 
 This provider solves that problem by converting complex YAML structures into flat key-value pairs that can be easily used with Helm's `set_sensitive` blocks or any other Terraform resource that requires flattened configuration data.
+
+## Key Features
+
+- **Order Preservation**: Maintains the exact key order from your original YAML files
+- **Dot Notation**: Nested objects become `parent.child` keys
+- **Bracket Notation**: Arrays become `parent[0]`, `parent[1]` keys
+- **Mixed Structures**: Handles complex combinations like `parent.array[0].child`
+- **Type Conversion**: All values converted to strings for Terraform compatibility
+- **Null Handling**: Null values become empty strings
+- **Performance**: Single-pass parsing with order preservation
 
 ## Installation
 
@@ -68,6 +78,37 @@ database:
   "database.replicas[0].host": "replica1",
   "database.replicas[1].host": "replica2"
 }
+```
+
+## Order Preservation Example
+
+This provider maintains the exact order from your YAML files, which is crucial for consistent reconstruction:
+
+**Input:**
+```yaml
+receivers:
+  - name: blackhole
+  - name: discord_prometheus
+    discord_config:
+      - webhook_url: "https://example.com/webhook"
+```
+
+**Output (order preserved):**
+```json
+{
+  "receivers[0].name": "blackhole",
+  "receivers[1].name": "discord_prometheus",
+  "receivers[1].discord_config[0].webhook_url": "https://example.com/webhook"
+}
+```
+
+When reconstructed, this maintains the original structure:
+```yaml
+receivers:
+- name: blackhole
+- name: discord_prometheus          # ✅ name comes first (as in original)
+  discord_config:                   # ✅ discord_config comes second (as in original)
+  - webhook_url: https://example.com/webhook
 ```
 
 ## License

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     yamlflattener = {
       source  = "Perun-Engineering/yamlflattener"
-      version = "~> 0.1"
+      version = "~> 0.2"
     }
   }
 }

--- a/examples/complete-example/main.tf
+++ b/examples/complete-example/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     yamlflattener = {
-      source  = "registry.terraform.io/terraform/yamlflattener"
+      source  = "perun-engineering/yamlflattener"
       version = ">= 0.2.0"
     }
   }

--- a/examples/complete-example/main.tf
+++ b/examples/complete-example/main.tf
@@ -13,8 +13,8 @@ provider "yamlflattener" {
 }
 
 # Example 1: Using data source with inline YAML content
-data "yamlflattener_flatten" "app_config" {
-  yaml_content = <<EOT
+locals {
+  app_config_yaml = <<EOT
 application:
   name: "example-app"
   version: "1.0.0"
@@ -61,6 +61,10 @@ monitoring:
 EOT
 }
 
+data "yamlflattener_flatten" "app_config" {
+  yaml_content = local.app_config_yaml
+}
+
 # Example 2: Using data source with external YAML file
 data "yamlflattener_flatten" "external_config" {
   yaml_file = "${path.module}/config.yaml"
@@ -91,7 +95,7 @@ features:
     beta_features: true
 EOT
 
-  # flattened_features = provider::yamlflattener::flatten(local.feature_flags)
+  flattened_features = provider::yamlflattener::flatten(local.feature_flags)
 
 }
 
@@ -176,8 +180,8 @@ output "equivalence_test" {
   description = "Test that data source and function produce identical results"
   value = {
     datasource_result = data.yamlflattener_flatten.app_config.flattened["application.name"]
-    # function_result   = provider::yamlflattener::flatten(data.yamlflattener_flatten.app_config.yaml_content)["application.name"]
-    # are_equal        = data.yamlflattener_flatten.app_config.flattened["application.name"] == provider::yamlflattener::flatten(data.yamlflattener_flatten.app_config.yaml_content)["application.name"]
+    function_result   = provider::yamlflattener::flatten(local.app_config_yaml)["application.name"]
+    are_equal        = data.yamlflattener_flatten.app_config.flattened["application.name"] == provider::yamlflattener::flatten(local.app_config_yaml)["application.name"]
   }
 }
 

--- a/examples/complete-example/main.tf
+++ b/examples/complete-example/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     yamlflattener = {
       source  = "registry.terraform.io/terraform/yamlflattener"
-      version = ">= 0.1.0"
+      version = ">= 0.2.0"
     }
   }
 }

--- a/internal/flattener/flattener_test.go
+++ b/internal/flattener/flattener_test.go
@@ -4,11 +4,9 @@ import (
 	"os"
 	"reflect"
 	"testing"
-
-	"gopkg.in/yaml.v3"
 )
 
-func TestFlattenYAML(t *testing.T) {
+func TestFlattenYAMLString(t *testing.T) {
 	flattener := NewFlattener()
 
 	tests := []struct {
@@ -98,7 +96,7 @@ empty_object: {}
 			wantErr:  false,
 		},
 		{
-			name:     "Nil input",
+			name:     "Empty YAML string",
 			yamlStr:  "",
 			expected: nil,
 			wantErr:  true,
@@ -107,25 +105,15 @@ empty_object: {}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var yamlData interface{}
-			var err error
-
-			if tt.yamlStr != "" {
-				err = yaml.Unmarshal([]byte(tt.yamlStr), &yamlData)
-				if err != nil {
-					t.Fatalf("Failed to parse test YAML: %v", err)
-				}
-			}
-
-			result, err := flattener.FlattenYAML(yamlData)
+			result, err := flattener.FlattenYAMLString(tt.yamlStr)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("FlattenYAML() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("FlattenYAMLString() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
 			if !tt.wantErr {
 				if !reflect.DeepEqual(result, tt.expected) {
-					t.Errorf("FlattenYAML() = %v, want %v", result, tt.expected)
+					t.Errorf("FlattenYAMLString() = %v, want %v", result, tt.expected)
 				}
 			}
 		})
@@ -201,73 +189,16 @@ mixed_array:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var yamlData interface{}
-			var err error
-
-			if tt.yamlStr != "" {
-				err = yaml.Unmarshal([]byte(tt.yamlStr), &yamlData)
-				if err != nil {
-					t.Fatalf("Failed to parse test YAML: %v", err)
-				}
-			}
-
-			result, err := flattener.FlattenYAML(yamlData)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("FlattenYAML() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-
-			if !tt.wantErr {
-				if !reflect.DeepEqual(result, tt.expected) {
-					t.Errorf("FlattenYAML() = %v, want %v", result, tt.expected)
-				}
-			}
-		})
-	}
-}
-
-func TestFlattenYAMLString(t *testing.T) {
-	flattener := NewFlattener()
-
-	tests := []struct {
-		name       string
-		yamlString string
-		expected   map[string]string
-		wantErr    bool
-	}{
-		{
-			name:       "Valid YAML string",
-			yamlString: "key: value\nkey2:\n  nested: value2",
-			expected: map[string]string{
-				"key":         "value",
-				"key2.nested": "value2",
-			},
-			wantErr: false,
-		},
-		{
-			name:       "Empty YAML string",
-			yamlString: "",
-			expected:   nil,
-			wantErr:    true,
-		},
-		{
-			name:       "Invalid YAML string",
-			yamlString: "key: : value",
-			expected:   nil,
-			wantErr:    true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := flattener.FlattenYAMLString(tt.yamlString)
+			result, err := flattener.FlattenYAMLString(tt.yamlStr)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FlattenYAMLString() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
-			if !tt.wantErr && !reflect.DeepEqual(result, tt.expected) {
-				t.Errorf("FlattenYAMLString() = %v, want %v", result, tt.expected)
+			if !tt.wantErr {
+				if !reflect.DeepEqual(result, tt.expected) {
+					t.Errorf("FlattenYAMLString() = %v, want %v", result, tt.expected)
+				}
 			}
 		})
 	}

--- a/internal/flattener/order_preservation_test.go
+++ b/internal/flattener/order_preservation_test.go
@@ -1,0 +1,111 @@
+package flattener
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestOrderPreservation tests that the flattener preserves the original YAML key order
+func TestOrderPreservation(t *testing.T) {
+	flattener := NewFlattener()
+
+	tests := []struct {
+		name     string
+		yamlStr  string
+		expected map[string]string
+	}{
+		{
+			name: "Alertmanager receivers preserve original order",
+			yamlStr: `alertmanager:
+    config:
+        receivers:
+            - name: blackhole
+            - name: discord_prometheus
+              discord_config:
+                - webhook_url: https://example.com/webhook1
+            - name: discord_alerts
+              discord_config:
+                - webhook_url: https://example.com/webhook2`,
+			expected: map[string]string{
+				"alertmanager.config.receivers[0].name":                          "blackhole",
+				"alertmanager.config.receivers[1].name":                          "discord_prometheus",
+				"alertmanager.config.receivers[1].discord_config[0].webhook_url": "https://example.com/webhook1",
+				"alertmanager.config.receivers[2].name":                          "discord_alerts",
+				"alertmanager.config.receivers[2].discord_config[0].webhook_url": "https://example.com/webhook2",
+			},
+		},
+		{
+			name: "Simple object preserves key order",
+			yamlStr: `name: discord_prometheus
+discord_config:
+  - webhook_url: test_url`,
+			expected: map[string]string{
+				"name":                          "discord_prometheus",
+				"discord_config[0].webhook_url": "test_url",
+			},
+		},
+		{
+			name: "Mixed order keys preserved",
+			yamlStr: `zebra: last
+alpha: first
+beta: second`,
+			expected: map[string]string{
+				"zebra": "last",
+				"alpha": "first",
+				"beta":  "second",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := flattener.FlattenYAMLString(tt.yamlStr)
+			if err != nil {
+				t.Fatalf("FlattenYAMLString() error = %v", err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("FlattenYAMLString() = %v, want %v", result, tt.expected)
+			}
+
+			// Run multiple times to ensure consistency
+			for i := 0; i < 3; i++ {
+				result2, err := flattener.FlattenYAMLString(tt.yamlStr)
+				if err != nil {
+					t.Fatalf("Run %d: FlattenYAMLString() error = %v", i+1, err)
+				}
+
+				if !reflect.DeepEqual(result2, result) {
+					t.Errorf("Run %d: Results are not consistent", i+1)
+				}
+			}
+		})
+	}
+}
+
+// TestOrderPreservationConsistency ensures that the order is preserved consistently across runs
+func TestOrderPreservationConsistency(t *testing.T) {
+	flattener := NewFlattener()
+
+	yamlStr := `name: discord_prometheus
+discord_config:
+  - webhook_url: test_url
+other_field: value`
+
+	// Run multiple times and ensure the same result
+	var firstResult map[string]string
+	for i := 0; i < 5; i++ {
+		result, err := flattener.FlattenYAMLString(yamlStr)
+		if err != nil {
+			t.Fatalf("Run %d: FlattenYAMLString() error = %v", i+1, err)
+		}
+
+		if i == 0 {
+			firstResult = result
+		} else if !reflect.DeepEqual(result, firstResult) {
+			t.Errorf("Run %d: Results are not consistent with first run", i+1)
+			t.Errorf("First result: %v", firstResult)
+			t.Errorf("Current result: %v", result)
+		}
+	}
+}

--- a/internal/provider/acceptance_test.go
+++ b/internal/provider/acceptance_test.go
@@ -430,7 +430,7 @@ terraform {
   required_providers {
     yamlflattener = {
       source = "registry.terraform.io/terraform/yamlflattener"
-      version = ">= 0.1.0"
+      version = ">= 0.2.0"
     }
   }
 }
@@ -445,7 +445,7 @@ installation:
   status: "success"
   provider:
     name: "yamlflattener"
-    version: "0.1.0"
+    version: "0.2.0"
   features:
     - "data_source"
     - "provider_function"

--- a/internal/provider/acceptance_test.go
+++ b/internal/provider/acceptance_test.go
@@ -429,7 +429,7 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     yamlflattener = {
-      source = "registry.terraform.io/terraform/yamlflattener"
+      source = "perun-engineering/yamlflattener"
       version = ">= 0.2.0"
     }
   }

--- a/internal/provider/final_integration_test.go
+++ b/internal/provider/final_integration_test.go
@@ -254,7 +254,7 @@ func TestFinalIntegration_ProviderInstallationWorkflow(t *testing.T) {
 terraform {
   required_providers {
     yamlflattener = {
-      source = "registry.terraform.io/terraform/yamlflattener"
+      source = "perun-engineering/yamlflattener"
       version = ">= 0.2.0"
     }
   }

--- a/internal/provider/final_integration_test.go
+++ b/internal/provider/final_integration_test.go
@@ -255,7 +255,7 @@ terraform {
   required_providers {
     yamlflattener = {
       source = "registry.terraform.io/terraform/yamlflattener"
-      version = ">= 0.1.0"
+      version = ">= 0.2.0"
     }
   }
 }
@@ -271,7 +271,7 @@ data "yamlflattener_flatten" "test" {
 installation:
   test: "success"
   provider: "yamlflattener"
-  version: "0.1.0"
+  version: "0.2.0"
 EOT
 }
 
@@ -281,7 +281,7 @@ output "function_test" {
 function:
   test: "success"
   provider: "yamlflattener"
-  version: "0.1.0"
+  version: "0.2.0"
 EOT
 )
 }
@@ -321,7 +321,7 @@ data "yamlflattener_flatten" "installation_test" {
 installation:
   test: "success"
   provider: "yamlflattener"
-  version: "0.1.0"
+  version: "0.2.0"
 EOT
 }
 
@@ -352,7 +352,7 @@ output "function_test" {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckOutput("installation_test", "success"),
 					resource.TestCheckOutput("provider_name", "yamlflattener"),
-					resource.TestCheckOutput("provider_version", "0.1.0"),
+					resource.TestCheckOutput("provider_version", "0.2.0"),
 					resource.TestCheckOutput("function_test", "success"),
 				),
 			},

--- a/internal/provider/integration_test.go
+++ b/internal/provider/integration_test.go
@@ -279,7 +279,7 @@ terraform {
   required_providers {
     yamlflattener = {
       source = "example/yamlflattener"
-      version = "0.1.0"
+      version = "0.2.0"
     }
   }
 }

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
-		Address: "registry.terraform.io/terraform/yamlflattener",
+		Address: "registry.terraform.io/perun-engineering/yamlflattener",
 		Debug:   debug,
 	}
 

--- a/scripts/run-acceptance-tests.sh
+++ b/scripts/run-acceptance-tests.sh
@@ -162,8 +162,8 @@ test_installation_workflow() {
 terraform {
   required_providers {
     yamlflattener = {
-      source = "registry.terraform.io/terraform/yamlflattener"
-      version = "0.1.0"
+      source = "perun-engineering/yamlflattener"
+      version = "0.2.0"
     }
   }
 }

--- a/scripts/run-final-tests.sh
+++ b/scripts/run-final-tests.sh
@@ -155,8 +155,8 @@ test_installation_workflow() {
 terraform {
   required_providers {
     yamlflattener = {
-      source = "registry.terraform.io/terraform/yamlflattener"
-      version = ">= 0.1.0"
+      source = "perun-engineering/yamlflattener"
+      version = ">= 0.2.0"
     }
   }
 }


### PR DESCRIPTION
- Remove legacy interface{}-based flattening system
- Keep only yaml.Node-based implementation for order preservation  
- Extract common validation and prefix building logic
- Update tests to use single implementation
- Add order preservation tests
- Update documentation and examples
- Update version to 0.2.0
- Fix provider source references

Eliminates ~88 lines of redundant code while maintaining full functionality and adding order preservation.