### PR TITLE
fix: resolve GitHub Actions PR creation restriction in security-updates workflow

### DIFF
--- a/.github/workflows/security-updates.yml
+++ b/.github/workflows/security-updates.yml
@@ -107,6 +107,10 @@ jobs:
           git push origin $BRANCH_NAME
 
           # Create PR using GitHub CLI
+          # Note: Using GH_PAT instead of GITHUB_TOKEN because GitHub Actions
+          # is not permitted to create or approve pull requests with the default token.
+          # The GH_PAT secret should be a Personal Access Token or GitHub App token
+          # with 'pull-requests: write' and 'contents: write' permissions.
           gh pr create \
             --title "Security: Update dependencies $(date +%Y-%m-%d)" \
             --body "This PR updates dependencies to fix security vulnerabilities and keep dependencies up to date.\n\nAutomatically created by the Security Updates workflow." \
@@ -114,4 +118,4 @@ jobs:
             --base main \
             --head $BRANCH_NAME
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Overview

This PR fixes the error `GitHub Actions is not permitted to create or approve pull requests (createPullRequest)` that occurs in the `.github/workflows/security-updates.yml` workflow file.

## Problem

The workflow was failing at the `gh pr create` command with the following error:
```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
Error: Process completed with exit code 1.
```

This issue occurs because the default `GITHUB_TOKEN` has security restrictions that prevent it from creating or approving pull requests. This is a GitHub security feature to prevent workflows from automatically creating PRs that could trigger other workflows, potentially creating recursive workflow executions.

## Solution

Updated the workflow to use a Personal Access Token (PAT) or GitHub App token instead of the default `GITHUB_TOKEN` for the pull request creation step.

### Changes Made

1. **Modified the PR creation step** (lines 110-121):
   - Replaced `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` with `GH_TOKEN: ${{ secrets.GH_PAT }}`
   - Added explanatory comments documenting why this change is necessary
   - Specified the required permissions: `pull-requests: write` and `contents: write`

2. **Documentation**: Added inline comments explaining:
   - Why the default `GITHUB_TOKEN` cannot be used
   - What type of token should be used (`GH_PAT` secret)
   - Required permissions for the alternative token

## Requirements

⚠️ **Action Required**: A `GH_PAT` secret must be configured in the repository settings with a Personal Access Token or GitHub App token that has the following permissions:
- `pull-requests: write`
- `contents: write`

## Testing

After merging this PR and configuring the `GH_PAT` secret, the security-updates workflow will be able to:
- Successfully create pull requests for dependency updates
- Bypass the GitHub Actions restriction on PR creation

## Additional Notes

- This PR also follows the required branch naming convention (`bugfix/security-updates-workflow`) as specified in the branch protection workflow
- The previous branch name `clone-repository-20251208-061431` did not follow the required pattern: `^(feature|bugfix|hotfix|release|docs|refactor|test|ci|chore)/[a-z0-9_-]+$`

## References

- [GitHub Actions Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
- [Creating a Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `security-updates.yml` to use `GH_TOKEN` from `secrets.GH_PAT` for `gh pr create`, replacing `GITHUB_TOKEN`, and documents required permissions.
> 
> - **CI/Workflow**:
>   - Update `/.github/workflows/security-updates.yml`:
>     - Replace `GITHUB_TOKEN` with `GH_TOKEN: ${{ secrets.GH_PAT }}` for `gh pr create`.
>     - Add comments explaining GitHub Actions restriction and required token permissions (`pull-requests: write`, `contents: write`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3978479c378effcdc52513b8031833fc9a234dc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->