### PR TITLE
fix: bump Go to 1.25.10 to resolve stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-yamlflattener
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.19.0


### PR DESCRIPTION
## What

Bumps the Go directive in `go.mod` from `1.25.8` to `1.25.10`.

## Why

`govulncheck` flags 5 **reachable** standard-library vulnerabilities when building under Go 1.25.8 (the source of issue #57):

| ID | Package | Fixed in |
|----|---------|----------|
| GO-2026-4971 | `net` (Dial/Listen NUL panic) | 1.25.10 |
| GO-2026-4947 | `crypto/x509` (chain building) | 1.25.9 |
| GO-2026-4946 | `crypto/x509` (policy validation) | 1.25.9 |
| GO-2026-4870 | `crypto/tls` (TLS 1.3 KeyUpdate DoS) | 1.25.9 |
| GO-2026-4865 | `html/template` (XSS context tracking) | 1.25.9 |

`net` requires 1.25.10, so 1.25.10 is the minimum that clears all five. Verified locally: build, tests, and `govulncheck ./...` all pass under 1.25.10 ("No vulnerabilities found").

Closes #57