### PR TITLE
ci: exempt Dependabot and Renovate from branch-protection checks

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Check PR title
+        if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
         uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,6 +43,7 @@ jobs:
           requireScope: false
 
       - name: Check branch name
+        if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
         run: |
           BRANCH_NAME=${GITHUB_HEAD_REF}
           if [[ ! $BRANCH_NAME =~ ^(feature|bugfix|hotfix|release|docs|refactor|test|ci|chore)/[a-z0-9_-]+$ ]]; then


### PR DESCRIPTION
## What

Skip the **PR title** and **branch name** steps in `Branch Protection Check` when the actor is `dependabot[bot]` or `renovate[bot]`.

## Why

Bot branches such as `dependabot/github_actions/actions/add-to-project-2.0.0` can't match the `type/branch-name` regex (`^(feature|...|chore)/[a-z0-9_-]+$`), so the check failed on **every** Dependabot PR — e.g. the open #58. The gate stays fully active for human contributors.

Unblocks #58 and all future automated dependency PRs.